### PR TITLE
Fix for LLAMA_WIN_VER default value, fixes #5158

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ if (NOT MSVC)
 endif()
 
 if (WIN32)
-    option(LLAMA_WIN_VER                     "llama: Windows Version"                           0x602)
+    set(LLAMA_WIN_VER "0x602" CACHE STRING "llama: Windows Version")
 endif()
 
 # 3rd party libs


### PR DESCRIPTION
Updated CMakeLists.txt to set `LLAMA_WIN_VER` with `set()` instead of `option()` (which is specifically for booleans).